### PR TITLE
Arrange RUN instruction(s) according to best practises

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 FROM centos:centos6
 
-RUN yum -y update
-RUN yum -y install gcc gcc-c++ rpmdevtools tar yum-utils
-RUN yum -y install epel-release
-RUN yum -y install https://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
+RUN yum -y install epel-release && \
+    yum -y install wget https://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm && \
+    yum -y update && \
+    yum -y install \
+        gcc \
+        gcc-c++ \
+        rpmdevtools \
+        tar \
+        yum-utils \
+    && \
+    yum clean all
 
 RUN useradd -m -s /bin/bash build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos6
 
 RUN yum -y install epel-release && \
     yum -y install wget https://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm && \
-    yum -y update && \
+    yum -y update --exclude=filesystem && \
     yum -y install \
         gcc \
         gcc-c++ \


### PR DESCRIPTION
Individual RUN instructions are cached, so `yum -y update` will be
cached if it's run independently before rest of yum commands.

This patch arranges all yum commands under single RUN instruction. It
also splits individual packages to own alphabetically sorted list for
easier patch review in future.

Two gotchas:
- erlang-solutions dot rpm requires wget but doesn't state it in rpm
  itself. Maybe fix it to upstream?
- Best Practices' warns about `apt-get upgrade` failing in
  unpriviledged container. Is this the case with `yum update` also?

For reference, see Dockerfile Best Practices for RUN instruction:

  https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
