### PR TITLE
Improve gathering of CircleCI build artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,4 @@ cd ../SRPMS
 yum-builddep -y *.src.rpm
 runuser build -c "rpmbuild --rebuild *.src.rpm"
 
-test -d /output && \
-    cp *.src.rpm ../RPMS/*/*.rpm /output
+mkdir /output && cp *.src.rpm ../RPMS/*/*.rpm /output

--- a/circle.yml
+++ b/circle.yml
@@ -11,13 +11,12 @@ dependencies:
     - docker build --pull -t build-image .
 
 test:
-  pre:
-    - mkdir output
   override:
-    - docker run -ti -v `pwd`/output:/output --name build-container build-image
+    - docker run -ti --name build-container build-image
+    - docker cp build-container:/output/. $CIRCLE_ARTIFACTS
 
 deployment:
   release:
     tag: /\d+(\.\d+)*(\-\d+)*/
     commands:
-      - github-release "${GITHUB_API_TOKEN}" "${CIRCLE_PROJECT_USERNAME}" "${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_TAG}" output/*
+      - github-release "${GITHUB_API_TOKEN}" "${CIRCLE_PROJECT_USERNAME}" "${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_TAG}" $CIRCLE_ARTIFACTS/*


### PR DESCRIPTION
Use docker cp to copy the build artifcats into $CIRCLE_ARTIFACTS making
them also available for download in the CircleCI dashboard.
