### PR TITLE
Cut dependencies for building ejabberd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
 FROM centos:centos6
 
 RUN yum -y update --exclude=filesystem && \
-    yum -y install epel-release && \
     yum -y install \
         gcc \
         gcc-c++ \
         rpmdevtools \
         tar \
-        yum-utils \
-    && \
-    yum clean all
+        yum-utils
 
 COPY erlang_solutions.asc /etc/pki/rpm-gpg/
 COPY erlang_solutions.repo /etc/yum.repos.d/
 RUN rpm --import /etc/pki/rpm-gpg/erlang_solutions.asc
-
-RUN useradd -m -s /bin/bash build
 
 WORKDIR /home/build
 RUN mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 COPY ejabberd.spec rpmbuild/SPECS/
 COPY sources rpmbuild/SOURCES/
 COPY build.sh ./
-RUN chown -R build:build .
+RUN useradd -m -s /bin/bash build && \
+    chown -R build:build .
+
+RUN spectool -C rpmbuild/SOURCES/ -g rpmbuild/SPECS/ejabberd.spec
+RUN sed -n 's:^BuildRequires\: *\([^ ]*\).*:\1:p' rpmbuild/SPECS/ejabberd.spec | xargs yum -y install
 
 CMD sh build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ COPY erlang_solutions.asc /etc/pki/rpm-gpg/
 COPY erlang_solutions.repo /etc/yum.repos.d/
 RUN rpm --import /etc/pki/rpm-gpg/erlang_solutions.asc
 
+RUN useradd -m -s /bin/bash build
 WORKDIR /home/build
 RUN mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 COPY ejabberd.spec rpmbuild/SPECS/
 COPY sources rpmbuild/SOURCES/
 COPY build.sh ./
-RUN useradd -m -s /bin/bash build && \
-    chown -R build:build .
+RUN chown -R build:build .
 
 RUN spectool -C rpmbuild/SOURCES/ -g rpmbuild/SPECS/ejabberd.spec
 RUN sed -n 's:^BuildRequires\: *\([^ ]*\).*:\1:p' rpmbuild/SPECS/ejabberd.spec | xargs yum -y install

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Upon completion the command will instruct you in setting up your environment.
 Create a Docker image ```build-image``` from which a container can be launched. The blueprints can be found from the file ```Dockerfile```.
 
 ```
-$ docker build -t build-image .
+$ docker build -t build-image --rm .
 ```
 
 This may take a moment or two.

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
+#!/bin/sh
+
 cd ./rpmbuild/SPECS
-runuser build -c "spectool -C ../SOURCES -g ejabberd.spec"
 runuser build -c "rpmbuild -bs ejabberd.spec"
 
 cd ../SRPMS

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
   pre:
     - pip install https://github.com/abusesa/github-release/archive/master.tar.gz
   override:
-    - docker build --pull -t build-image .
+    - docker build --pull --rm -t build-image .
 
 test:
   override:

--- a/ejabberd.spec
+++ b/ejabberd.spec
@@ -20,7 +20,7 @@ Patch2:         ejabberd-ejabberdctl.patch
 Patch3:         ejabberd-collab.patch
 
 BuildRequires:  expat-devel
-BuildRequires:  openssl-devel >= 0.9.8
+BuildRequires:  openssl-devel
 BuildRequires:  pam-devel
 BuildRequires:  libyaml-devel
 BuildRequires:  erlang-compiler

--- a/ejabberd.spec
+++ b/ejabberd.spec
@@ -23,7 +23,11 @@ BuildRequires:  expat-devel
 BuildRequires:  openssl-devel >= 0.9.8
 BuildRequires:  pam-devel
 BuildRequires:  libyaml-devel
-BuildRequires:  erlang
+BuildRequires:  erlang-compiler
+BuildRequires:  erlang-edoc
+BuildRequires:  erlang-erl_interface
+BuildRequires:  erlang-eunit
+BuildRequires:  erlang-parsetools
 BuildRequires:  git
 BuildRequires:  autoconf
 BuildRequires:  automake


### PR DESCRIPTION
Items in this PR:
- Do not require full Erlang for building. The erlang package seems to be some kind of meta package with big list of dependencies. Include only what is necessary for build. Speeds up build quite a bit.
- Do more in docker container build. Try to get as much as possible of the CentOS packages installed. This mostly benefits debugging and devel builds.
- build docker image with `--rm` to remove the intermediate containers.
- Remove OpenSSL version dependency from ejabberd build.
