### PR TITLE
Increase max open files from 1024 to 4096

### DIFF
--- a/sources/ejabberd.sysconfig
+++ b/sources/ejabberd.sysconfig
@@ -10,4 +10,4 @@ CONFIG_FILE=/etc/ejabberd/ejabberd.yml
 ## open files as it has active connections, so if you have a few
 ## hundred or more users you will want to set this.
 #
-ULIMIT_MAX_FILES=1024
+ULIMIT_MAX_FILES=4096


### PR DESCRIPTION
eJabberd and Erlang loves to use file handles. Failure to provide those from OS side can lead to nasty things.
